### PR TITLE
Fix Installation Instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Uses browser native crypto to be the lightest possible module you can have, with
 You need to have Node.js installed.
 
 ```bash
-yarn install @metamask/browser-passworder
+yarn add @metamask/browser-passworder
 ```
 
 ## Usage


### PR DESCRIPTION
Resolve this error on installation step.

```
yarn install v1.22.17
error `install` has been replaced with `add` to add new dependencies. Run "yarn add @metamask/browser-passworder" instead.
```