### PR TITLE
Update TypeScript to latest stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "dist/"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project tsconfig.build.json",
+    "build:clean": "rimraf dist && yarn build",
     "buildTest": "yarn build && browserify dist/index.js --standalone encryptor -o test/bundle.js",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
@@ -56,7 +57,8 @@
     "playwright": "^1.27.1",
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.3.0",
-    "typescript": "^4.3.4"
+    "rimraf": "^3.0.2",
+    "typescript": "^4.8.4"
   },
   "packageManager": "yarn@3.2.4",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -273,10 +273,9 @@ export function serializeBufferFromStorage(str: string): Uint8Array {
  */
 export function serializeBufferForStorage(buffer: Uint8Array): string {
   let result = '0x';
-  const len = buffer.length || buffer.byteLength;
-  for (let i = 0; i < len; i++) {
-    result += unprefixedHex(buffer[i]);
-  }
+  buffer.forEach((value) => {
+    result += unprefixedHex(value);
+  });
   return result;
 }
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "inlineSources": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,16 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "esModuleInterop": true,
-    "inlineSources": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
     "lib": ["DOM", "ES2020"],
     "module": "CommonJS",
-    "moduleResolution": "Node",
-    "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true,
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noErrorTruncation": true,
+    "noUncheckedIndexedAccess": true,
     "strict": true,
-    "target": "ES2017"
+    "target": "es2017"
   },
-  "include": ["src/**/*.ts"]
+  "exclude": ["./dist/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,7 +126,8 @@ __metadata:
     playwright: ^1.27.1
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.3.0
-    typescript: ^4.3.4
+    rimraf: ^3.0.2
+    typescript: ^4.8.4
   languageName: unknown
   linkType: soft
 
@@ -4878,23 +4879,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.3.4":
-  version: 4.3.4
-  resolution: "typescript@npm:4.3.4"
+"typescript@npm:^4.8.4":
+  version: 4.8.4
+  resolution: "typescript@npm:4.8.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 75e1f2769c7ff38c718523d05eaf1c2611dbf92c0ab0f85f603ead9bb23416af2009a5dac46e76ef6a207a8508fa53f51b43a41f2a91b1241b53cd744c16128c
+  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.3.4#~builtin<compat/typescript>":
-  version: 4.3.4
-  resolution: "typescript@patch:typescript@npm%3A4.3.4#~builtin<compat/typescript>::version=4.3.4&hash=701156"
+"typescript@patch:typescript@^4.8.4#~builtin<compat/typescript>":
+  version: 4.8.4
+  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=701156"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6ccc2e1148e172da119ea4b72c66395a0c18a53884d21fb82bb4503a948a7169e9961defe24a359040a3d77bf5ff338945804296e0e27c87b5bd22ea1d25781b
+  checksum: 301459fc3eb3b1a38fe91bf96d98eb55da88a9cb17b4ef80b4d105d620f4d547ba776cc27b44cc2ef58b66eda23fe0a74142feb5e79a6fb99f54fc018a696afa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
TypeScript has been updated to the latest stable version. Our standard module TypeScript configuration has been brought over from the module template as well, including a separate configuration file for production builds (as opposed to the root file used for things like tests).

A `build:clean` has been added as well, for consistency with the module template.