### PR TITLE
Provide exported key with encryption

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -181,9 +181,7 @@ export async function decryptWithKey<R>(
  * @param {string} keyString - keyString to import
  * @returns {CryptoKey}
  */
-export async function createKeyFromString(
-  keyString: string,
-): Promise<CryptoKey> {
+export async function importKey(keyString: string): Promise<CryptoKey> {
   const key = await window.crypto.subtle.importKey(
     EXPORT_FORMAT,
     JSON.parse(keyString),

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,13 +47,14 @@ export async function encrypt<R>(
  *
  * @param {string} password - password to use for encryption
  * @param {R} dataObj - data to encrypt
+ * @param {R} salt - salt used to encrypt
  * @returns {Promise<DetailedEncryptionResult>} object with vault and exportedKeyString
  */
 export async function encryptWithDetail<R>(
   password: string,
   dataObj: R,
+  salt = generateSalt(),
 ): Promise<DetailedEncryptionResult> {
-  const salt = generateSalt();
   const key = await keyFromPassword(password, salt);
   const exportedKeyString = await exportKey(key);
   const vault = await encrypt(password, dataObj, key, salt);
@@ -200,7 +201,7 @@ export async function createKeyFromString(
  * @param {CryptoKey} key - key to export
  * @returns {string}
  */
-async function exportKey(key: CryptoKey): Promise<string> {
+export async function exportKey(key: CryptoKey): Promise<string> {
   const exportedKey = await window.crypto.subtle.exportKey(EXPORT_FORMAT, key);
   return JSON.stringify(exportedKey);
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -381,14 +381,10 @@ test('encryptor:decrypt encrypted data using key derived from wrong password', a
   ).rejects.toThrow('Incorrect password');
 });
 
-test('encryptor:createKeyFromString generates valid CryptoKey', async ({
-  page,
-}) => {
+test('encryptor:importKey generates valid CryptoKey', async ({ page }) => {
   const isKey = await page.evaluate(
     async (args) => {
-      const key = await window.encryptor.createKeyFromString(
-        args.SAMPLE_EXPORTED_KEY,
-      );
+      const key = await window.encryptor.importKey(args.SAMPLE_EXPORTED_KEY);
       return key instanceof CryptoKey;
     },
     { SAMPLE_EXPORTED_KEY },
@@ -401,9 +397,7 @@ test('encryptor:exportKey generates valid CryptoKey string', async ({
 }) => {
   const keyString = await page.evaluate(
     async (args) => {
-      const key = await window.encryptor.createKeyFromString(
-        args.SAMPLE_EXPORTED_KEY,
-      );
+      const key = await window.encryptor.importKey(args.SAMPLE_EXPORTED_KEY);
       return await window.encryptor.exportKey(key);
     },
     { SAMPLE_EXPORTED_KEY },
@@ -449,7 +443,7 @@ test('encryptor:decryptWithKey provide same data when using exported key from en
   // Use the exported key and vault to properly decrypt the data
   const decryptWithKeyResult = await page.evaluate(
     async (args) => {
-      const key = await window.encryptor.createKeyFromString(args.keyString);
+      const key = await window.encryptor.importKey(args.keyString);
       return await window.encryptor.decryptWithKey(key, JSON.parse(args.data));
     },
     { data: vault, keyString: exportedKeyString },
@@ -489,7 +483,7 @@ test('encryptor:decryptWithDetail works with password after encryption with key'
   const newData = { ...startingData, bar: 'more data' };
   const encryptWithKeyResult = await page.evaluate(
     async (args) => {
-      const key = await window.encryptor.createKeyFromString(args.keyString);
+      const key = await window.encryptor.importKey(args.keyString);
       return await window.encryptor.encryptWithKey(key, args.data);
     },
     { data: newData, keyString: exportedKeyString },
@@ -532,7 +526,7 @@ test('encryptor:encryptWithKey works with decryptWithKey', async ({ page }) => {
   const newData = { ...startingData, bar: 'more data' };
   const encryptWithKeyResult = await page.evaluate(
     async (args) => {
-      const key = await window.encryptor.createKeyFromString(args.keyString);
+      const key = await window.encryptor.importKey(args.keyString);
       const result = await window.encryptor.encryptWithKey(key, args.data);
 
       return {
@@ -546,9 +540,7 @@ test('encryptor:encryptWithKey works with decryptWithKey', async ({ page }) => {
   // Prove that a vault created with key can be decrypted with password
   const decryptedResult = await page.evaluate(
     async (args) => {
-      const key = await window.encryptor.createKeyFromString(
-        args.exportedKeyString,
-      );
+      const key = await window.encryptor.importKey(args.exportedKeyString);
       return await window.encryptor.decryptWithKey(key, args.data);
     },
     {


### PR DESCRIPTION
Prerequisite to https://github.com/MetaMask/KeyringController/pull/152

Provides the key in string format so it may be used to unlock.

Supercedes https://github.com/MetaMask/browser-passworder/pull/20