### PR TITLE
feat: introduce encryption result version

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -140,449 +140,956 @@ test('encryptor:encrypt & decrypt with wrong password', async ({ page }) => {
  * `a sample passw0rd`. This should be left unmodified, as it's used to test
  * that decrypting older encrypted data continues to work.
  */
-const sampleEncryptedData = {
+const sampleEncryptedDataV1 = {
   data: 'bfCvija6QfwqARmHsKT7ZR0GHi8yjz7iVEZodRVx3xI2yzFHwq7+B/U=',
   iv: 'N9s46G5sp37A7wtf3vo/LA==',
   salt: '+uzzUKmbAdwkjw8rILhJvZE9dOfz2ecF5Gtf7yNkyyE=',
 };
 
-test('encryptor:decrypt encrypted data', async ({ page }) => {
-  const password = 'a sample passw0rd';
-  const expectedData = { foo: 'data to encrypt' };
+const sampleEncryptedDataV2 = {
+  version: '2.0',
+  data: '/7Pqz+WFluKFlmPhG3fKEHalzZqEvwvtFZibXVK3133fhtp72MJnEmY=',
+  iv: '3DkwjtOhrfjmmhueQL/hOA==',
+  salt: '0u9YlQFIaC8l8nUnq+K0M8/cMy4xKYEeHE6XCSGuTtQ=',
+};
 
-  const decryptedData = await page.evaluate(
-    async (args) =>
-      await window.encryptor.decrypt(
-        args.password,
-        JSON.stringify(args.sampleEncryptedData),
-      ),
-    { sampleEncryptedData, password },
-  );
+test.describe('with version 1.0', () => {
+  test('encryptor:decrypt encrypted data', async ({ page }) => {
+    const password = 'a sample passw0rd';
+    const expectedData = { foo: 'data to encrypt' };
 
-  expect(decryptedData).toStrictEqual(expectedData);
-});
-
-test('encryptor:decrypt encrypted data using wrong password', async ({
-  page,
-}) => {
-  const wrongPassword = 'a wrong password';
-
-  await expect(
-    page.evaluate(
+    const decryptedData = await page.evaluate(
       async (args) =>
         await window.encryptor.decrypt(
-          args.wrongPassword,
-          JSON.stringify(args.sampleEncryptedData),
-        ),
-      { sampleEncryptedData, wrongPassword },
-    ),
-  ).rejects.toThrow('Incorrect password');
-});
-
-test('encryptor:decryptWithDetail returns same vault as decrypt', async ({
-  page,
-}) => {
-  const password = 'a sample passw0rd';
-
-  const decryptResult = await page.evaluate(
-    async (args) => {
-      return await window.encryptor.decrypt(
-        args.password,
-        JSON.stringify(args.sampleEncryptedData),
-      );
-    },
-    { password, sampleEncryptedData },
-  );
-
-  const decryptWithDetailResult = await page.evaluate(
-    async (args) => {
-      return await window.encryptor.decryptWithDetail(
-        args.password,
-        JSON.stringify(args.sampleEncryptedData),
-      );
-    },
-    { password, sampleEncryptedData },
-  );
-
-  expect(JSON.stringify(decryptResult)).toStrictEqual(
-    JSON.stringify(decryptWithDetailResult.vault),
-  );
-  expect(Object.keys(decryptWithDetailResult).length).toBe(3);
-  expect(typeof decryptWithDetailResult.exportedKeyString).toStrictEqual(
-    'string',
-  );
-});
-
-test('encryptor:encrypt using key then decrypt', async ({ page }) => {
-  const password = 'a sample passw0rd';
-  const data = { foo: 'data to encrypt' };
-  const salt = await page.evaluate(() => window.encryptor.generateSalt());
-
-  const encryptedData = await page.evaluate(
-    async (args) => {
-      const key = await window.encryptor.keyFromPassword(
-        args.password,
-        args.salt,
-      );
-      return await window.encryptor.encryptWithKey(key, args.data);
-    },
-    { data, password, salt },
-  );
-  expect(Object.keys(encryptedData).sort()).toStrictEqual(['data', 'iv']);
-
-  const encryptedString = JSON.stringify(
-    Object.assign({}, encryptedData, { salt }),
-  );
-  const decryptedData = await page.evaluate(
-    async (args) =>
-      await window.encryptor.decrypt(args.password, args.encryptedString),
-    { encryptedString, password },
-  );
-
-  expect(decryptedData).toStrictEqual(data);
-});
-
-test('encryptor:encrypt using key then decrypt using wrong password', async ({
-  page,
-}) => {
-  const password = 'a sample passw0rd';
-  const wrongPassword = 'a wrong password';
-  const data = { foo: 'data to encrypt' };
-  const salt = await page.evaluate(() => window.encryptor.generateSalt());
-
-  const encryptedData = await page.evaluate(
-    async (args) => {
-      const key = await window.encryptor.keyFromPassword(
-        args.password,
-        args.salt,
-      );
-      return await window.encryptor.encryptWithKey(key, args.data);
-    },
-    { data, password, salt },
-  );
-  expect(Object.keys(encryptedData).sort()).toStrictEqual(['data', 'iv']);
-
-  const encryptedString = JSON.stringify(
-    Object.assign({}, encryptedData, { salt }),
-  );
-  await expect(
-    page.evaluate(
-      async (args) =>
-        await window.encryptor.decrypt(
-          args.wrongPassword,
-          args.encryptedString,
-        ),
-      { encryptedString, wrongPassword },
-    ),
-  ).rejects.toThrow('Incorrect password');
-});
-
-test('encryptor:encrypt then decrypt using key', async ({ page }) => {
-  const password = 'a sample passw0rd';
-  const data = { foo: 'data to encrypt' };
-
-  const encryptedString = await page.evaluate(
-    async (args) => await window.encryptor.encrypt(args.password, args.data),
-    { data, password },
-  );
-  expect(typeof encryptedString).toBe('string');
-  const encryptedData = JSON.parse(encryptedString);
-  const { salt } = encryptedData;
-  const encryptedPayload = { data: encryptedData.data, iv: encryptedData.iv };
-
-  const decryptedData = await page.evaluate(
-    async (args) => {
-      const key = await window.encryptor.keyFromPassword(
-        args.password,
-        args.salt,
-      );
-      return await window.encryptor.decryptWithKey(key, args.encryptedPayload);
-    },
-    { encryptedPayload, password, salt },
-  );
-
-  expect(decryptedData).toStrictEqual(data);
-});
-
-test('encryptor:encrypt then decrypt using key derived from wrong password', async ({
-  page,
-}) => {
-  const password = 'a sample passw0rd';
-  const wrongPassword = 'a wrong password';
-  const data = { foo: 'data to encrypt' };
-
-  const encryptedString = await page.evaluate(
-    async (args) => await window.encryptor.encrypt(args.password, args.data),
-    { data, password },
-  );
-  expect(typeof encryptedString).toBe('string');
-  const encryptedData = JSON.parse(encryptedString);
-  const { salt } = encryptedData;
-  const encryptedPayload = { data: encryptedData.data, iv: encryptedData.iv };
-
-  await expect(
-    page.evaluate(
-      async (args) => {
-        const key = await window.encryptor.keyFromPassword(
-          args.wrongPassword,
-          args.salt,
-        );
-        return await window.encryptor.decryptWithKey(
-          key,
-          args.encryptedPayload,
-        );
-      },
-      { encryptedPayload, salt, wrongPassword },
-    ),
-  ).rejects.toThrow('Incorrect password');
-});
-
-test('encryptor:decrypt encrypted data using key', async ({ page }) => {
-  const password = 'a sample passw0rd';
-  const expectedData = { foo: 'data to encrypt' };
-  const encryptedPayload = {
-    data: sampleEncryptedData.data,
-    iv: sampleEncryptedData.iv,
-  };
-  const { salt } = sampleEncryptedData;
-
-  const decryptedData = await page.evaluate(
-    async (args) => {
-      const key = await window.encryptor.keyFromPassword(
-        args.password,
-        args.salt,
-      );
-      return await window.encryptor.decryptWithKey(key, args.encryptedPayload);
-    },
-    { encryptedPayload, password, salt },
-  );
-
-  expect(decryptedData).toStrictEqual(expectedData);
-});
-
-test('encryptor:decrypt encrypted data using key derived from wrong password', async ({
-  page,
-}) => {
-  const wrongPassword = 'a wrong password';
-  const encryptedPayload = {
-    data: sampleEncryptedData.data,
-    iv: sampleEncryptedData.iv,
-  };
-  const { salt } = sampleEncryptedData;
-
-  await expect(
-    page.evaluate(
-      async (args) => {
-        const key = await window.encryptor.keyFromPassword(
-          args.wrongPassword,
-          args.salt,
-        );
-        return await window.encryptor.decryptWithKey(
-          key,
-          args.encryptedPayload,
-        );
-      },
-      { encryptedPayload, salt, wrongPassword },
-    ),
-  ).rejects.toThrow('Incorrect password');
-});
-
-test('encryptor:importKey generates valid CryptoKey', async ({ page }) => {
-  const isKey = await page.evaluate(
-    async (args) => {
-      const key = await window.encryptor.importKey(args.SAMPLE_EXPORTED_KEY);
-      return key instanceof CryptoKey;
-    },
-    { SAMPLE_EXPORTED_KEY },
-  );
-  expect(isKey).toBe(true);
-});
-
-test('encryptor:exportKey generates valid CryptoKey string', async ({
-  page,
-}) => {
-  const keyString = await page.evaluate(
-    async (args) => {
-      const key = await window.encryptor.importKey(args.SAMPLE_EXPORTED_KEY);
-      return await window.encryptor.exportKey(key);
-    },
-    { SAMPLE_EXPORTED_KEY },
-  );
-  expect(keyString).toStrictEqual(SAMPLE_EXPORTED_KEY);
-});
-
-test('encryptor:encryptWithDetail and decryptWithDetail provide same data', async ({
-  page,
-}) => {
-  const password = 'a sample passw0rd';
-  const data = { foo: 'data to encrypt' };
-
-  const { vault } = await page.evaluate(
-    async (args) =>
-      await window.encryptor.encryptWithDetail(args.password, args.data),
-    { data, password },
-  );
-
-  const decryptedDetail = await page.evaluate(
-    async (args) =>
-      await window.encryptor.decryptWithDetail(args.password, args.data),
-    { data: vault, password },
-  );
-
-  expect(JSON.stringify(decryptedDetail.vault)).toStrictEqual(
-    JSON.stringify(data),
-  );
-});
-
-test('encryptor:decryptWithKey provide same data when using exported key from encryptWithDetail', async ({
-  page,
-}) => {
-  const password = 'a sample passw0rd';
-  const data = { foo: 'data to encrypt' };
-
-  const { vault, exportedKeyString } = await page.evaluate(
-    async (args) =>
-      await window.encryptor.encryptWithDetail(args.password, args.data),
-    { data, password },
-  );
-
-  // Use the exported key and vault to properly decrypt the data
-  const decryptWithKeyResult = await page.evaluate(
-    async (args) => {
-      const key = await window.encryptor.importKey(args.keyString);
-      return await window.encryptor.decryptWithKey(key, JSON.parse(args.data));
-    },
-    { data: vault, keyString: exportedKeyString },
-  );
-
-  expect(JSON.stringify(decryptWithKeyResult)).toStrictEqual(
-    JSON.stringify(data),
-  );
-});
-
-test('encryptor:decryptWithDetail works with password after encryption with key', async ({
-  page,
-}) => {
-  const password = 'a sample passw0rd';
-  const startingData = { foo: 'data to encrypt' };
-
-  // Get an exported key to use
-  const { salt, exportedKeyString } = await page.evaluate(
-    async (args) => {
-      const usedSalt = window.encryptor.generateSalt();
-      const { exportedKeyString: newKeyString } =
-        await window.encryptor.encryptWithDetail(
           args.password,
-          args.data,
-          usedSalt,
+          JSON.stringify(args.sampleEncryptedDataV1),
+        ),
+      { sampleEncryptedDataV1, password },
+    );
+
+    expect(decryptedData).toStrictEqual(expectedData);
+  });
+
+  test('encryptor:decrypt encrypted data using wrong password', async ({
+    page,
+  }) => {
+    const wrongPassword = 'a wrong password';
+
+    await expect(
+      page.evaluate(
+        async (args) =>
+          await window.encryptor.decrypt(
+            args.wrongPassword,
+            JSON.stringify(args.sampleEncryptedDataV1),
+          ),
+        { sampleEncryptedDataV1, wrongPassword },
+      ),
+    ).rejects.toThrow('Incorrect password');
+  });
+
+  test('encryptor:decryptWithDetail returns same vault as decrypt', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+
+    const decryptResult = await page.evaluate(
+      async (args) => {
+        return await window.encryptor.decrypt(
+          args.password,
+          JSON.stringify(args.sampleEncryptedDataV1),
+        );
+      },
+      { password, sampleEncryptedDataV1 },
+    );
+
+    const decryptWithDetailResult = await page.evaluate(
+      async (args) => {
+        return await window.encryptor.decryptWithDetail(
+          args.password,
+          JSON.stringify(args.sampleEncryptedDataV1),
+        );
+      },
+      { password, sampleEncryptedDataV1 },
+    );
+
+    expect(JSON.stringify(decryptResult)).toStrictEqual(
+      JSON.stringify(decryptWithDetailResult.vault),
+    );
+    expect(Object.keys(decryptWithDetailResult).length).toBe(3);
+    expect(typeof decryptWithDetailResult.exportedKeyString).toStrictEqual(
+      'string',
+    );
+  });
+
+  test('encryptor:encrypt using key then decrypt', async ({ page }) => {
+    const password = 'a sample passw0rd';
+    const data = { foo: 'data to encrypt' };
+    const salt = await page.evaluate(() => window.encryptor.generateSalt());
+
+    const encryptedData = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.keyFromPassword(
+          args.password,
+          args.salt,
+        );
+        return await window.encryptor.encryptWithKey(key, args.data);
+      },
+      { data, password, salt },
+    );
+    expect(Object.keys(encryptedData).sort()).toStrictEqual([
+      'data',
+      'iv',
+      'version',
+    ]);
+
+    const encryptedString = JSON.stringify(
+      Object.assign({}, encryptedData, { salt }),
+    );
+    const decryptedData = await page.evaluate(
+      async (args) =>
+        await window.encryptor.decrypt(args.password, args.encryptedString),
+      { encryptedString, password },
+    );
+
+    expect(decryptedData).toStrictEqual(data);
+  });
+
+  test('encryptor:encrypt using key then decrypt using wrong password', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const wrongPassword = 'a wrong password';
+    const data = { foo: 'data to encrypt' };
+    const salt = await page.evaluate(() => window.encryptor.generateSalt());
+
+    const encryptedData = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.keyFromPassword(
+          args.password,
+          args.salt,
+        );
+        return await window.encryptor.encryptWithKey(key, args.data);
+      },
+      { data, password, salt },
+    );
+    expect(Object.keys(encryptedData).sort()).toStrictEqual([
+      'data',
+      'iv',
+      'version',
+    ]);
+
+    const encryptedString = JSON.stringify(
+      Object.assign({}, encryptedData, { salt }),
+    );
+    await expect(
+      page.evaluate(
+        async (args) =>
+          await window.encryptor.decrypt(
+            args.wrongPassword,
+            args.encryptedString,
+          ),
+        { encryptedString, wrongPassword },
+      ),
+    ).rejects.toThrow('Incorrect password');
+  });
+
+  test('encryptor:encrypt then decrypt using key', async ({ page }) => {
+    const password = 'a sample passw0rd';
+    const data = { foo: 'data to encrypt' };
+
+    const encryptedString = await page.evaluate(
+      async (args) => await window.encryptor.encrypt(args.password, args.data),
+      { data, password },
+    );
+    expect(typeof encryptedString).toBe('string');
+    const encryptedData = JSON.parse(encryptedString);
+    const { salt } = encryptedData;
+    const encryptedPayload = {
+      data: encryptedData.data,
+      iv: encryptedData.iv,
+      version: encryptedData.version,
+    };
+
+    const decryptedData = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.keyFromPassword(
+          args.password,
+          args.salt,
+        );
+        return await window.encryptor.decryptWithKey(
+          key,
+          args.encryptedPayload,
+        );
+      },
+      { encryptedPayload, password, salt },
+    );
+
+    expect(decryptedData).toStrictEqual(data);
+  });
+
+  test('encryptor:encrypt then decrypt using key derived from wrong password', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const wrongPassword = 'a wrong password';
+    const data = { foo: 'data to encrypt' };
+
+    const encryptedString = await page.evaluate(
+      async (args) => await window.encryptor.encrypt(args.password, args.data),
+      { data, password },
+    );
+    expect(typeof encryptedString).toBe('string');
+    const encryptedData = JSON.parse(encryptedString);
+    const { salt } = encryptedData;
+    const encryptedPayload = {
+      data: encryptedData.data,
+      iv: encryptedData.iv,
+      version: encryptedData.version,
+    };
+
+    await expect(
+      page.evaluate(
+        async (args) => {
+          const key = await window.encryptor.keyFromPassword(
+            args.wrongPassword,
+            args.salt,
+          );
+          return await window.encryptor.decryptWithKey(
+            key,
+            args.encryptedPayload,
+          );
+        },
+        { encryptedPayload, salt, wrongPassword },
+      ),
+    ).rejects.toThrow('Incorrect password');
+  });
+
+  test('encryptor:decrypt encrypted data using key', async ({ page }) => {
+    const password = 'a sample passw0rd';
+    const expectedData = { foo: 'data to encrypt' };
+    const encryptedPayload = {
+      data: sampleEncryptedDataV1.data,
+      iv: sampleEncryptedDataV1.iv,
+    };
+    const { salt } = sampleEncryptedDataV1;
+
+    const decryptedData = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.keyFromPassword(
+          args.password,
+          args.salt,
+          10000,
+        );
+        return await window.encryptor.decryptWithKey(
+          key,
+          args.encryptedPayload,
+        );
+      },
+      { encryptedPayload, password, salt },
+    );
+
+    expect(decryptedData).toStrictEqual(expectedData);
+  });
+
+  test('encryptor:decrypt encrypted data using key derived from wrong password', async ({
+    page,
+  }) => {
+    const wrongPassword = 'a wrong password';
+    const encryptedPayload = {
+      data: sampleEncryptedDataV1.data,
+      iv: sampleEncryptedDataV1.iv,
+    };
+    const { salt } = sampleEncryptedDataV1;
+
+    await expect(
+      page.evaluate(
+        async (args) => {
+          const key = await window.encryptor.keyFromPassword(
+            args.wrongPassword,
+            args.salt,
+          );
+          return await window.encryptor.decryptWithKey(
+            key,
+            args.encryptedPayload,
+          );
+        },
+        { encryptedPayload, salt, wrongPassword },
+      ),
+    ).rejects.toThrow('Incorrect password');
+  });
+
+  test('encryptor:importKey generates valid CryptoKey', async ({ page }) => {
+    const isKey = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.SAMPLE_EXPORTED_KEY);
+        return key instanceof CryptoKey;
+      },
+      { SAMPLE_EXPORTED_KEY },
+    );
+    expect(isKey).toBe(true);
+  });
+
+  test('encryptor:exportKey generates valid CryptoKey string', async ({
+    page,
+  }) => {
+    const keyString = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.SAMPLE_EXPORTED_KEY);
+        return await window.encryptor.exportKey(key);
+      },
+      { SAMPLE_EXPORTED_KEY },
+    );
+    expect(keyString).toStrictEqual(SAMPLE_EXPORTED_KEY);
+  });
+
+  test('encryptor:encryptWithDetail and decryptWithDetail provide same data', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const data = { foo: 'data to encrypt' };
+
+    const { vault } = await page.evaluate(
+      async (args) =>
+        await window.encryptor.encryptWithDetail(args.password, args.data),
+      { data, password },
+    );
+
+    const decryptedDetail = await page.evaluate(
+      async (args) =>
+        await window.encryptor.decryptWithDetail(args.password, args.data),
+      { data: vault, password },
+    );
+
+    expect(JSON.stringify(decryptedDetail.vault)).toStrictEqual(
+      JSON.stringify(data),
+    );
+  });
+
+  test('encryptor:decryptWithKey provide same data when using exported key from encryptWithDetail', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const data = { foo: 'data to encrypt' };
+
+    const { vault, exportedKeyString } = await page.evaluate(
+      async (args) =>
+        await window.encryptor.encryptWithDetail(args.password, args.data),
+      { data, password },
+    );
+
+    // Use the exported key and vault to properly decrypt the data
+    const decryptWithKeyResult = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.keyString);
+        return await window.encryptor.decryptWithKey(
+          key,
+          JSON.parse(args.data),
+        );
+      },
+      { data: vault, keyString: exportedKeyString },
+    );
+
+    expect(JSON.stringify(decryptWithKeyResult)).toStrictEqual(
+      JSON.stringify(data),
+    );
+  });
+
+  test('encryptor:decryptWithDetail works with password after encryption with key', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const startingData = { foo: 'data to encrypt' };
+
+    // Get an exported key to use
+    const { salt, exportedKeyString } = await page.evaluate(
+      async (args) => {
+        const usedSalt = window.encryptor.generateSalt();
+        const { exportedKeyString: newKeyString } =
+          await window.encryptor.encryptWithDetail(
+            args.password,
+            args.data,
+            usedSalt,
+          );
+
+        return {
+          salt: usedSalt,
+          exportedKeyString: newKeyString,
+        };
+      },
+      { data: startingData, password },
+    );
+
+    // Update the data, encrypt using key
+    const newData = { ...startingData, bar: 'more data' };
+    const encryptWithKeyResult = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.keyString);
+        return await window.encryptor.encryptWithKey(key, args.data);
+      },
+      { data: newData, keyString: exportedKeyString },
+    );
+
+    // Mock the encrypted object
+    const decryptable = {
+      ...encryptWithKeyResult,
+      salt,
+    };
+
+    // Prove that a vault created with key can be decrypted with password
+    const decryptedResult = await page.evaluate(
+      async (args) =>
+        await window.encryptor.decryptWithDetail(args.password, args.data),
+      { password, data: JSON.stringify(decryptable) },
+    );
+
+    expect(JSON.stringify(decryptedResult.vault)).toStrictEqual(
+      JSON.stringify(newData),
+    );
+  });
+
+  test('encryptor:encryptWithKey works with decryptWithKey', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const startingData = { foo: 'data to encrypt' };
+
+    // Get an exported key to use
+    const exportedKeyString = await page.evaluate(
+      async (args) => {
+        const { exportedKeyString: newKeyString } =
+          await window.encryptor.encryptWithDetail(args.password, args.data);
+
+        return newKeyString;
+      },
+      { data: startingData, password },
+    );
+
+    // Update the data, encrypt using key
+    const newData = { ...startingData, bar: 'more data' };
+    const encryptWithKeyResult = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.keyString);
+        const result = await window.encryptor.encryptWithKey(key, args.data);
+
+        return {
+          encryptWithKeyResult: result,
+          exportedKeyString: await window.encryptor.exportKey(key),
+        };
+      },
+      { data: newData, keyString: exportedKeyString },
+    );
+
+    // Prove that a vault created with key can be decrypted with password
+    const decryptedResult = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.exportedKeyString);
+        return await window.encryptor.decryptWithKey(key, args.data);
+      },
+      {
+        exportedKeyString: encryptWithKeyResult.exportedKeyString,
+        data: encryptWithKeyResult.encryptWithKeyResult,
+      },
+    );
+
+    expect(JSON.stringify(decryptedResult)).toStrictEqual(
+      JSON.stringify(newData),
+    );
+  });
+
+  test('encryptor:keyFromPassword cannot be exported by default', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const data = { foo: 'data to encrypt' };
+    const salt = await page.evaluate(() => window.encryptor.generateSalt());
+
+    const exportResult = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.keyFromPassword(
+          args.password,
+          args.salt,
         );
 
-      return {
-        salt: usedSalt,
-        exportedKeyString: newKeyString,
-      };
-    },
-    { data: startingData, password },
-  );
+        try {
+          const result = await window.encryptor.exportKey(key);
+          return result;
+        } catch (e) {
+          return 'error';
+        }
+      },
+      { data, password, salt },
+    );
 
-  // Update the data, encrypt using key
-  const newData = { ...startingData, bar: 'more data' };
-  const encryptWithKeyResult = await page.evaluate(
-    async (args) => {
-      const key = await window.encryptor.importKey(args.keyString);
-      return await window.encryptor.encryptWithKey(key, args.data);
-    },
-    { data: newData, keyString: exportedKeyString },
-  );
-
-  // Mock the encrypted object
-  const decryptable = {
-    ...encryptWithKeyResult,
-    salt,
-  };
-
-  // Prove that a vault created with key can be decrypted with password
-  const decryptedResult = await page.evaluate(
-    async (args) =>
-      await window.encryptor.decryptWithDetail(args.password, args.data),
-    { password, data: JSON.stringify(decryptable) },
-  );
-
-  expect(JSON.stringify(decryptedResult.vault)).toStrictEqual(
-    JSON.stringify(newData),
-  );
+    expect(exportResult).toStrictEqual('error');
+  });
 });
 
-test('encryptor:encryptWithKey works with decryptWithKey', async ({ page }) => {
-  const password = 'a sample passw0rd';
-  const startingData = { foo: 'data to encrypt' };
+test.describe('with version 2.0', () => {
+  test('encryptor:decrypt encrypted data', async ({ page }) => {
+    const password = 'a sample passw0rd';
+    const expectedData = { foo: 'data to encrypt' };
 
-  // Get an exported key to use
-  const exportedKeyString = await page.evaluate(
-    async (args) => {
-      const { exportedKeyString: newKeyString } =
-        await window.encryptor.encryptWithDetail(args.password, args.data);
+    const decryptedData = await page.evaluate(
+      async (args) =>
+        await window.encryptor.decrypt(
+          args.password,
+          JSON.stringify(args.sampleEncryptedDataV2),
+        ),
+      { sampleEncryptedDataV2, password },
+    );
 
-      return newKeyString;
-    },
-    { data: startingData, password },
-  );
+    expect(decryptedData).toStrictEqual(expectedData);
+  });
 
-  // Update the data, encrypt using key
-  const newData = { ...startingData, bar: 'more data' };
-  const encryptWithKeyResult = await page.evaluate(
-    async (args) => {
-      const key = await window.encryptor.importKey(args.keyString);
-      const result = await window.encryptor.encryptWithKey(key, args.data);
+  test('encryptor:decrypt encrypted data using wrong password', async ({
+    page,
+  }) => {
+    const wrongPassword = 'a wrong password';
 
-      return {
-        encryptWithKeyResult: result,
-        exportedKeyString: await window.encryptor.exportKey(key),
-      };
-    },
-    { data: newData, keyString: exportedKeyString },
-  );
+    await expect(
+      page.evaluate(
+        async (args) =>
+          await window.encryptor.decrypt(
+            args.wrongPassword,
+            JSON.stringify(args.sampleEncryptedDataV2),
+          ),
+        { sampleEncryptedDataV2, wrongPassword },
+      ),
+    ).rejects.toThrow('Incorrect password');
+  });
 
-  // Prove that a vault created with key can be decrypted with password
-  const decryptedResult = await page.evaluate(
-    async (args) => {
-      const key = await window.encryptor.importKey(args.exportedKeyString);
-      return await window.encryptor.decryptWithKey(key, args.data);
-    },
-    {
-      exportedKeyString: encryptWithKeyResult.exportedKeyString,
-      data: encryptWithKeyResult.encryptWithKeyResult,
-    },
-  );
+  test('encryptor:decryptWithDetail returns same vault as decrypt', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
 
-  expect(JSON.stringify(decryptedResult)).toStrictEqual(
-    JSON.stringify(newData),
-  );
-});
+    const decryptResult = await page.evaluate(
+      async (args) => {
+        return await window.encryptor.decrypt(
+          args.password,
+          JSON.stringify(args.sampleEncryptedDataV2),
+        );
+      },
+      { password, sampleEncryptedDataV2 },
+    );
 
-test('encryptor:keyFromPassword cannot be exported by default', async ({
-  page,
-}) => {
-  const password = 'a sample passw0rd';
-  const data = { foo: 'data to encrypt' };
-  const salt = await page.evaluate(() => window.encryptor.generateSalt());
+    const decryptWithDetailResult = await page.evaluate(
+      async (args) => {
+        return await window.encryptor.decryptWithDetail(
+          args.password,
+          JSON.stringify(args.sampleEncryptedDataV2),
+        );
+      },
+      { password, sampleEncryptedDataV2 },
+    );
 
-  const exportResult = await page.evaluate(
-    async (args) => {
-      const key = await window.encryptor.keyFromPassword(
-        args.password,
-        args.salt,
-      );
+    expect(JSON.stringify(decryptResult)).toStrictEqual(
+      JSON.stringify(decryptWithDetailResult.vault),
+    );
+    expect(Object.keys(decryptWithDetailResult).length).toBe(3);
+    expect(typeof decryptWithDetailResult.exportedKeyString).toStrictEqual(
+      'string',
+    );
+  });
 
-      try {
-        const result = await window.encryptor.exportKey(key);
-        return result;
-      } catch (e) {
-        return 'error';
-      }
-    },
-    { data, password, salt },
-  );
+  test('encryptor:encrypt using key then decrypt', async ({ page }) => {
+    const password = 'a sample passw0rd';
+    const data = { foo: 'data to encrypt' };
+    const salt = await page.evaluate(() => window.encryptor.generateSalt());
 
-  expect(exportResult).toStrictEqual('error');
+    const encryptedData = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.keyFromPassword(
+          args.password,
+          args.salt,
+        );
+        return await window.encryptor.encryptWithKey(key, args.data);
+      },
+      { data, password, salt },
+    );
+    expect(Object.keys(encryptedData).sort()).toStrictEqual([
+      'data',
+      'iv',
+      'version',
+    ]);
+
+    const encryptedString = JSON.stringify(
+      Object.assign({}, encryptedData, { salt }),
+    );
+    const decryptedData = await page.evaluate(
+      async (args) =>
+        await window.encryptor.decrypt(args.password, args.encryptedString),
+      { encryptedString, password },
+    );
+
+    expect(decryptedData).toStrictEqual(data);
+  });
+
+  test('encryptor:encrypt using key then decrypt using wrong password', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const wrongPassword = 'a wrong password';
+    const data = { foo: 'data to encrypt' };
+    const salt = await page.evaluate(() => window.encryptor.generateSalt());
+
+    const encryptedData = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.keyFromPassword(
+          args.password,
+          args.salt,
+        );
+        return await window.encryptor.encryptWithKey(key, args.data);
+      },
+      { data, password, salt },
+    );
+    expect(Object.keys(encryptedData).sort()).toStrictEqual([
+      'data',
+      'iv',
+      'version',
+    ]);
+
+    const encryptedString = JSON.stringify(
+      Object.assign({}, encryptedData, { salt }),
+    );
+    await expect(
+      page.evaluate(
+        async (args) =>
+          await window.encryptor.decrypt(
+            args.wrongPassword,
+            args.encryptedString,
+          ),
+        { encryptedString, wrongPassword },
+      ),
+    ).rejects.toThrow('Incorrect password');
+  });
+
+  test('encryptor:encrypt then decrypt using key', async ({ page }) => {
+    const password = 'a sample passw0rd';
+    const data = { foo: 'data to encrypt' };
+
+    const encryptedString = await page.evaluate(
+      async (args) => await window.encryptor.encrypt(args.password, args.data),
+      { data, password },
+    );
+    expect(typeof encryptedString).toBe('string');
+    const encryptedData = JSON.parse(encryptedString);
+    const { salt } = encryptedData;
+    const encryptedPayload = {
+      data: encryptedData.data,
+      iv: encryptedData.iv,
+      version: encryptedData.version,
+    };
+
+    const decryptedData = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.keyFromPassword(
+          args.password,
+          args.salt,
+        );
+        return await window.encryptor.decryptWithKey(
+          key,
+          args.encryptedPayload,
+        );
+      },
+      { encryptedPayload, password, salt },
+    );
+
+    expect(decryptedData).toStrictEqual(data);
+  });
+
+  test('encryptor:encrypt then decrypt using key derived from wrong password', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const wrongPassword = 'a wrong password';
+    const data = { foo: 'data to encrypt' };
+
+    const encryptedString = await page.evaluate(
+      async (args) => await window.encryptor.encrypt(args.password, args.data),
+      { data, password },
+    );
+    expect(typeof encryptedString).toBe('string');
+    const encryptedData = JSON.parse(encryptedString);
+    const { salt } = encryptedData;
+    const encryptedPayload = {
+      data: encryptedData.data,
+      iv: encryptedData.iv,
+      version: encryptedData.version,
+    };
+
+    await expect(
+      page.evaluate(
+        async (args) => {
+          const key = await window.encryptor.keyFromPassword(
+            args.wrongPassword,
+            args.salt,
+          );
+          return await window.encryptor.decryptWithKey(
+            key,
+            args.encryptedPayload,
+          );
+        },
+        { encryptedPayload, salt, wrongPassword },
+      ),
+    ).rejects.toThrow('Incorrect password');
+  });
+
+  test('encryptor:decrypt encrypted data using key', async ({ page }) => {
+    const password = 'a sample passw0rd';
+    const expectedData = { foo: 'data to encrypt' };
+    const encryptedPayload = {
+      data: sampleEncryptedDataV2.data,
+      iv: sampleEncryptedDataV2.iv,
+    };
+    const { salt } = sampleEncryptedDataV2;
+
+    const decryptedData = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.keyFromPassword(
+          args.password,
+          args.salt,
+        );
+        return await window.encryptor.decryptWithKey(
+          key,
+          args.encryptedPayload,
+        );
+      },
+      { encryptedPayload, password, salt },
+    );
+
+    expect(decryptedData).toStrictEqual(expectedData);
+  });
+
+  test('encryptor:decrypt encrypted data using key derived from wrong password', async ({
+    page,
+  }) => {
+    const wrongPassword = 'a wrong password';
+    const encryptedPayload = {
+      data: sampleEncryptedDataV2.data,
+      iv: sampleEncryptedDataV2.iv,
+    };
+    const { salt } = sampleEncryptedDataV2;
+
+    await expect(
+      page.evaluate(
+        async (args) => {
+          const key = await window.encryptor.keyFromPassword(
+            args.wrongPassword,
+            args.salt,
+          );
+          return await window.encryptor.decryptWithKey(
+            key,
+            args.encryptedPayload,
+          );
+        },
+        { encryptedPayload, salt, wrongPassword },
+      ),
+    ).rejects.toThrow('Incorrect password');
+  });
+
+  test('encryptor:importKey generates valid CryptoKey', async ({ page }) => {
+    const isKey = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.SAMPLE_EXPORTED_KEY);
+        return key instanceof CryptoKey;
+      },
+      { SAMPLE_EXPORTED_KEY },
+    );
+    expect(isKey).toBe(true);
+  });
+
+  test('encryptor:exportKey generates valid CryptoKey string', async ({
+    page,
+  }) => {
+    const keyString = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.SAMPLE_EXPORTED_KEY);
+        return await window.encryptor.exportKey(key);
+      },
+      { SAMPLE_EXPORTED_KEY },
+    );
+    expect(keyString).toStrictEqual(SAMPLE_EXPORTED_KEY);
+  });
+
+  test('encryptor:encryptWithDetail and decryptWithDetail provide same data', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const data = { foo: 'data to encrypt' };
+
+    const { vault } = await page.evaluate(
+      async (args) =>
+        await window.encryptor.encryptWithDetail(args.password, args.data),
+      { data, password },
+    );
+
+    const decryptedDetail = await page.evaluate(
+      async (args) =>
+        await window.encryptor.decryptWithDetail(args.password, args.data),
+      { data: vault, password },
+    );
+
+    expect(JSON.stringify(decryptedDetail.vault)).toStrictEqual(
+      JSON.stringify(data),
+    );
+  });
+
+  test('encryptor:decryptWithKey provide same data when using exported key from encryptWithDetail', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const data = { foo: 'data to encrypt' };
+
+    const { vault, exportedKeyString } = await page.evaluate(
+      async (args) =>
+        await window.encryptor.encryptWithDetail(args.password, args.data),
+      { data, password },
+    );
+
+    // Use the exported key and vault to properly decrypt the data
+    const decryptWithKeyResult = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.keyString);
+        return await window.encryptor.decryptWithKey(
+          key,
+          JSON.parse(args.data),
+        );
+      },
+      { data: vault, keyString: exportedKeyString },
+    );
+
+    expect(JSON.stringify(decryptWithKeyResult)).toStrictEqual(
+      JSON.stringify(data),
+    );
+  });
+
+  test('encryptor:decryptWithDetail works with password after encryption with key', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const startingData = { foo: 'data to encrypt' };
+
+    // Get an exported key to use
+    const { salt, exportedKeyString } = await page.evaluate(
+      async (args) => {
+        const usedSalt = window.encryptor.generateSalt();
+        const { exportedKeyString: newKeyString } =
+          await window.encryptor.encryptWithDetail(
+            args.password,
+            args.data,
+            usedSalt,
+          );
+
+        return {
+          salt: usedSalt,
+          exportedKeyString: newKeyString,
+        };
+      },
+      { data: startingData, password },
+    );
+
+    // Update the data, encrypt using key
+    const newData = { ...startingData, bar: 'more data' };
+    const encryptWithKeyResult = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.keyString);
+        return await window.encryptor.encryptWithKey(key, args.data);
+      },
+      { data: newData, keyString: exportedKeyString },
+    );
+
+    // Mock the encrypted object
+    const decryptable = {
+      ...encryptWithKeyResult,
+      salt,
+    };
+
+    // Prove that a vault created with key can be decrypted with password
+    const decryptedResult = await page.evaluate(
+      async (args) =>
+        await window.encryptor.decryptWithDetail(args.password, args.data),
+      { password, data: JSON.stringify(decryptable) },
+    );
+
+    expect(JSON.stringify(decryptedResult.vault)).toStrictEqual(
+      JSON.stringify(newData),
+    );
+  });
+
+  test('encryptor:encryptWithKey works with decryptWithKey', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const startingData = { foo: 'data to encrypt' };
+
+    // Get an exported key to use
+    const exportedKeyString = await page.evaluate(
+      async (args) => {
+        const { exportedKeyString: newKeyString } =
+          await window.encryptor.encryptWithDetail(args.password, args.data);
+
+        return newKeyString;
+      },
+      { data: startingData, password },
+    );
+
+    // Update the data, encrypt using key
+    const newData = { ...startingData, bar: 'more data' };
+    const encryptWithKeyResult = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.keyString);
+        const result = await window.encryptor.encryptWithKey(key, args.data);
+
+        return {
+          encryptWithKeyResult: result,
+          exportedKeyString: await window.encryptor.exportKey(key),
+        };
+      },
+      { data: newData, keyString: exportedKeyString },
+    );
+
+    // Prove that a vault created with key can be decrypted with password
+    const decryptedResult = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.importKey(args.exportedKeyString);
+        return await window.encryptor.decryptWithKey(key, args.data);
+      },
+      {
+        exportedKeyString: encryptWithKeyResult.exportedKeyString,
+        data: encryptWithKeyResult.encryptWithKeyResult,
+      },
+    );
+
+    expect(JSON.stringify(decryptedResult)).toStrictEqual(
+      JSON.stringify(newData),
+    );
+  });
+
+  test('encryptor:keyFromPassword cannot be exported by default', async ({
+    page,
+  }) => {
+    const password = 'a sample passw0rd';
+    const data = { foo: 'data to encrypt' };
+    const salt = await page.evaluate(() => window.encryptor.generateSalt());
+
+    const exportResult = await page.evaluate(
+      async (args) => {
+        const key = await window.encryptor.keyFromPassword(
+          args.password,
+          args.salt,
+        );
+
+        try {
+          const result = await window.encryptor.exportKey(key);
+          return result;
+        } catch (e) {
+          return 'error';
+        }
+      },
+      { data, password, salt },
+    );
+
+    expect(exportResult).toStrictEqual('error');
+  });
 });


### PR DESCRIPTION
This PR introduces a `version` property in the `EncryptionResult` object. Adding a version to the encryption result object allows the use of different decryption algorithms or configurations based on it.

The current implementation (prior to this PR) is classified as version `1.0`, and for `EncryptionResult` objects that don't have a `version` property at all, version 1.0 is inferred: this ensures that the decryption methods of this library can still decrypt old versions. 

Moreover, this PR also adds a `2.0` version, where the encryption key is derived with increased iterations.

When encrypting, it is now possible to specify the version (defaults to `2.0`).

## Changes

- **BREAKING**: Added `iterations` optional argument to `keyFromPassword`with `600000` as default value
- **CHANGED**: Added optional `version` argument to `encryptWithDetail` with `2.0` as the default value
- **CHANGED**: Added optional `version` argument to `encryptWithKey` with `2.0` as the default value

