### PR TITLE
Pin Typescript minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.3.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.8.4"
+    "typescript": "~4.8.4"
   },
   "packageManager": "yarn@3.2.4",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,7 +127,7 @@ __metadata:
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.3.0
     rimraf: ^3.0.2
-    typescript: ^4.8.4
+    typescript: ~4.8.4
   languageName: unknown
   linkType: soft
 
@@ -4527,7 +4527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.8.4":
+"typescript@npm:~4.8.4":
   version: 4.8.4
   resolution: "typescript@npm:4.8.4"
   bin:
@@ -4537,7 +4537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.8.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@~4.8.4#~builtin<compat/typescript>":
   version: 4.8.4
   resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=701156"
   bin:


### PR DESCRIPTION
This PR pins the Typescript version to `~4.8.4`, to match the [module template](https://github.com/MetaMask/metamask-module-template/blob/f7a581ed927a3ed13fae75b50340b152da631fda/package.json#L72)