### PR TITLE
Export `isVaultUpdated` function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -541,7 +541,7 @@ function unwrapKey(encryptionKey: EncryptionKey | CryptoKey): CryptoKey {
  * @param vault - The vault to check.
  * @returns Whether or not the vault is an updated encryption format.
  */
-function isVaultUpdated(vault: string): boolean {
+export function isVaultUpdated(vault: string): boolean {
   const { keyMetadata } = JSON.parse(vault);
   return (
     isKeyDerivationOptions(keyMetadata) &&

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -915,3 +915,23 @@ test.describe('encryptor:updateVaultWithDetail', async () => {
     });
   });
 });
+
+test.describe('encryptor:isVaultUpdated', async () => {
+  test('should return true with new vault format', async ({ page }) => {
+    const isVaultUpdated = await page.evaluate(
+      async (args) => window.encryptor.isVaultUpdated(args.vault),
+      { vault: JSON.stringify(sampleEncryptedData) },
+    );
+
+    expect(isVaultUpdated).toBe(true);
+  });
+
+  test('should return false with old vault format', async ({ page }) => {
+    const isVaultUpdated = await page.evaluate(
+      async (args) => window.encryptor.isVaultUpdated(args.vault),
+      { vault: JSON.stringify(oldSampleEncryptedData) },
+    );
+
+    expect(isVaultUpdated).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR exports the `isVaultUpdate` function, to give clients the option to know if a vault is up to date, as opposed to updating it directly with `updateVault`.

See: https://github.com/MetaMask/core/issues/3582