### PR TITLE
Allow client to choose target iterations for `updateVault`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -435,17 +435,25 @@ export function generateSalt(byteCount = 32): string {
  *
  * @param vault - The vault to update.
  * @param password - The password to use for encryption.
+ * @param targetDerivationParams - The options to use for key derivation.
  * @returns A promise resolving to the updated vault.
  */
 export async function updateVault(
   vault: string,
   password: string,
+  targetDerivationParams = DEFAULT_DERIVATION_PARAMS,
 ): Promise<string> {
-  if (isVaultUpdated(vault)) {
+  if (isVaultUpdated(vault, targetDerivationParams)) {
     return vault;
   }
 
-  return encrypt(password, await decrypt(password, vault));
+  return encrypt(
+    password,
+    await decrypt(password, vault),
+    undefined,
+    undefined,
+    targetDerivationParams,
+  );
 }
 
 /**
@@ -457,19 +465,23 @@ export async function updateVault(
  *
  * @param encryptionResult - The encrypted data to update.
  * @param password - The password to use for encryption.
+ * @param targetDerivationParams - The options to use for key derivation.
  * @returns A promise resolving to the updated encrypted data and exported key.
  */
 export async function updateVaultWithDetail(
   encryptionResult: DetailedEncryptionResult,
   password: string,
+  targetDerivationParams = DEFAULT_DERIVATION_PARAMS,
 ): Promise<DetailedEncryptionResult> {
-  if (isVaultUpdated(encryptionResult.vault)) {
+  if (isVaultUpdated(encryptionResult.vault, targetDerivationParams)) {
     return encryptionResult;
   }
 
   return encryptWithDetail(
     password,
     await decrypt(password, encryptionResult.vault),
+    undefined,
+    targetDerivationParams,
   );
 }
 
@@ -539,14 +551,17 @@ function unwrapKey(encryptionKey: EncryptionKey | CryptoKey): CryptoKey {
  * Checks if the provided vault is an updated encryption format.
  *
  * @param vault - The vault to check.
+ * @param targetDerivationParams - The options to use for key derivation.
  * @returns Whether or not the vault is an updated encryption format.
  */
-export function isVaultUpdated(vault: string): boolean {
+export function isVaultUpdated(
+  vault: string,
+  targetDerivationParams = DEFAULT_DERIVATION_PARAMS,
+): boolean {
   const { keyMetadata } = JSON.parse(vault);
   return (
     isKeyDerivationOptions(keyMetadata) &&
-    keyMetadata.algorithm === DEFAULT_DERIVATION_PARAMS.algorithm &&
-    keyMetadata.params.iterations ===
-      DEFAULT_DERIVATION_PARAMS.params.iterations
+    keyMetadata.algorithm === targetDerivationParams.algorithm &&
+    keyMetadata.params.iterations === targetDerivationParams.params.iterations
   );
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -934,4 +934,38 @@ test.describe('encryptor:isVaultUpdated', async () => {
 
     expect(isVaultUpdated).toBe(false);
   });
+
+  test('should return false if vault does not match target params', async ({
+    page,
+  }) => {
+    const isVaultUpdated = await page.evaluate(
+      async (args) =>
+        window.encryptor.isVaultUpdated(args.vault, {
+          algorithm: 'PBKDF2',
+          params: {
+            iterations: 100_000,
+          },
+        }),
+      { vault: JSON.stringify(sampleEncryptedData) },
+    );
+
+    expect(isVaultUpdated).toBe(false);
+  });
+
+  test('should return true if vault matches target params', async ({
+    page,
+  }) => {
+    const isVaultUpdated = await page.evaluate(
+      async (args) =>
+        window.encryptor.isVaultUpdated(args.vault, {
+          algorithm: 'PBKDF2',
+          params: {
+            iterations: 900_000,
+          },
+        }),
+      { vault: JSON.stringify(sampleEncryptedData) },
+    );
+
+    expect(isVaultUpdated).toBe(true);
+  });
 });


### PR DESCRIPTION
This PR adds an optional argument to `updateVault`, `updateVaultWithDetail` and `isVaultUpdated`, to specify the targeted derivation parameters.

This allows the client to choose a different number of iterations than the default `browser-passworder` one (900K) 